### PR TITLE
core: implement OntobiStore (Oxigraph WASM wrapper + N-Quads persistence)

### DIFF
--- a/packages/core/src/rdf/store.ts
+++ b/packages/core/src/rdf/store.ts
@@ -54,6 +54,10 @@ export class OntobiStore {
 
   /**
    * Execute a SPARQL SELECT query. Returns an array of binding maps.
+   *
+   * NOTE: Triples are stored in named graphs (one per concept file).
+   * Queries must use GRAPH ?g { ... } or GRAPH <uri> { ... } to match them.
+   * A bare WHERE { ?s ?p ?o } only queries the default graph (always empty).
    */
   query(sparql: string): SparqlResult {
     this.assertInitialized()
@@ -100,19 +104,19 @@ export class OntobiStore {
 
       SELECT DISTINCT ?node ?label ?identifier ?pred WHERE {
         {
-          <${subjectUri}> (skos:broader|skos:narrower|skos:related)${depthClause} ?node .
-          ?node skos:prefLabel ?label .
-          ?node schema:identifier ?identifier .
+          GRAPH ?g1 { <${subjectUri}> (skos:broader|skos:narrower|skos:related)${depthClause} ?node . }
+          GRAPH ?g2 { ?node skos:prefLabel ?label . }
+          GRAPH ?g3 { ?node schema:identifier ?identifier . }
           BIND("outgoing" AS ?pred)
         } UNION {
-          ?node (skos:broader|skos:narrower|skos:related)${depthClause} <${subjectUri}> .
-          ?node skos:prefLabel ?label .
-          ?node schema:identifier ?identifier .
+          GRAPH ?g4 { ?node (skos:broader|skos:narrower|skos:related)${depthClause} <${subjectUri}> . }
+          GRAPH ?g5 { ?node skos:prefLabel ?label . }
+          GRAPH ?g6 { ?node schema:identifier ?identifier . }
           BIND("incoming" AS ?pred)
         } UNION {
           BIND(<${subjectUri}> AS ?node)
-          <${subjectUri}> skos:prefLabel ?label .
-          <${subjectUri}> schema:identifier ?identifier .
+          GRAPH ?g7 { <${subjectUri}> skos:prefLabel ?label . }
+          GRAPH ?g8 { <${subjectUri}> schema:identifier ?identifier . }
           BIND("self" AS ?pred)
         }
       }
@@ -123,7 +127,7 @@ export class OntobiStore {
 
       SELECT DISTINCT ?source ?target ?relation WHERE {
         VALUES ?relation { skos:broader skos:narrower skos:related }
-        ?source ?relation ?target .
+        GRAPH ?g { ?source ?relation ?target . }
         FILTER(?source = <${subjectUri}> || ?target = <${subjectUri}>)
       }
     `

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { OntobiStore } from '../src/rdf/store.js'
+import { generateTriples } from '../src/rdf/triple-generator.js'
+import type { ConceptMetadata } from '../src/types.js'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFile, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const centroid: ConceptMetadata = {
+  prefLabel: 'Centroid',
+  definition: 'The center point of a cluster.',
+  broader: ['concept-k-means-clustering'],
+  narrower: [],
+  related: ['concept-distance-metrics'],
+  type: 'DefinedTerm',
+  identifier: 'concept-centroid',
+  dateCreated: '2026-01-17',
+  aliases: [],
+  tags: ['#concept'],
+  filePath: '_concepts/Centroid.md',
+}
+
+const kMeans: ConceptMetadata = {
+  prefLabel: 'K-Means Clustering',
+  definition: 'A centroid-based clustering algorithm.',
+  broader: [],
+  narrower: ['concept-centroid'],
+  related: [],
+  type: 'DefinedTerm',
+  identifier: 'concept-k-means-clustering',
+  dateCreated: '2026-01-18',
+  aliases: [],
+  tags: ['#concept'],
+  filePath: '_concepts/KMeansClustering.md',
+}
+
+const GRAPH_CENTROID = 'file:///_concepts/Centroid.md'
+const GRAPH_KMEANS = 'file:///_concepts/KMeansClustering.md'
+
+function tmpPath(name: string): string {
+  return join(tmpdir(), `ontobi-test-${name}-${Date.now()}.nq`)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OntobiStore', () => {
+  let store: OntobiStore
+  let persistPath: string
+
+  beforeEach(async () => {
+    persistPath = tmpPath('store')
+    store = new OntobiStore()
+    await store.initialize(persistPath)
+  })
+
+  afterEach(async () => {
+    if (existsSync(persistPath)) await rm(persistPath)
+  })
+
+  // ---- initialization -------------------------------------------------------
+
+  it('initializes without error on a fresh (non-existent) persistence path', () => {
+    // Reaching here without throw is sufficient
+    expect(store).toBeDefined()
+  })
+
+  it('throws if used before initialize()', async () => {
+    const raw = new OntobiStore()
+    expect(() => raw.query('SELECT * WHERE {}')).toThrow('not initialized')
+  })
+
+  // ---- loadTriples / query --------------------------------------------------
+
+  it('loads N-Quads and retrieves them via SELECT', async () => {
+    const nquads = generateTriples(centroid, GRAPH_CENTROID)
+    await store.loadTriples(nquads)
+
+    const results = store.query(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE {
+        GRAPH <${GRAPH_CENTROID}> {
+          <urn:ontobi:concept:concept-centroid> skos:prefLabel ?label .
+        }
+      }
+    `)
+
+    expect(results.length).toBe(1)
+    expect(results[0].get('label')).toBe('Centroid')
+  })
+
+  it('skips empty N-Quads without error', async () => {
+    await expect(store.loadTriples('')).resolves.toBeUndefined()
+    await expect(store.loadTriples('   \n  ')).resolves.toBeUndefined()
+  })
+
+  it('handles multiple graphs loaded independently', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+    await store.loadTriples(generateTriples(kMeans, GRAPH_KMEANS))
+
+    const results = store.query(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE {
+        GRAPH ?g { ?s skos:prefLabel ?label . }
+      }
+      ORDER BY ?label
+    `)
+
+    const labels = results.map((r) => r.get('label'))
+    expect(labels).toContain('Centroid')
+    expect(labels).toContain('K-Means Clustering')
+  })
+
+  // ---- clearGraph ----------------------------------------------------------
+
+  it('clearGraph removes triples from a named graph', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+    await store.loadTriples(generateTriples(kMeans, GRAPH_KMEANS))
+
+    // Verify both loaded
+    let results = store.query(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE { GRAPH ?g { ?s skos:prefLabel ?label . } }
+    `)
+    expect(results.length).toBeGreaterThanOrEqual(2)
+
+    // Clear centroid graph
+    await store.clearGraph(GRAPH_CENTROID)
+
+    results = store.query(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE { GRAPH ?g { ?s skos:prefLabel ?label . } }
+    `)
+    const labels = results.map((r) => r.get('label'))
+    expect(labels).not.toContain('Centroid')
+    expect(labels).toContain('K-Means Clustering')
+  })
+
+  it('clearGraph on a non-existent graph is silent (DROP SILENT)', async () => {
+    await expect(
+      store.clearGraph('file:///nonexistent.md')
+    ).resolves.toBeUndefined()
+  })
+
+  // ---- ask -----------------------------------------------------------------
+
+  it('ASK returns true for an existing triple', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+
+    const result = store.ask(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      ASK { GRAPH ?g { <urn:ontobi:concept:concept-centroid> skos:prefLabel ?l } }
+    `)
+    expect(result).toBe(true)
+  })
+
+  it('ASK returns false for a non-existent triple', async () => {
+    const result = store.ask(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      ASK { <urn:ontobi:concept:does-not-exist> skos:prefLabel ?l }
+    `)
+    expect(result).toBe(false)
+  })
+
+  // ---- queryRaw ------------------------------------------------------------
+
+  it('queryRaw returns valid SPARQL JSON string', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+
+    const raw = store.queryRaw(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE {
+        GRAPH <${GRAPH_CENTROID}> { <urn:ontobi:concept:concept-centroid> skos:prefLabel ?label . }
+      }
+    `)
+
+    const parsed = JSON.parse(raw) as { results: { bindings: unknown[] } }
+    expect(parsed.results.bindings.length).toBeGreaterThan(0)
+  })
+
+  // ---- dump / restore ------------------------------------------------------
+
+  it('dump writes an N-Quads file to disk', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+    await store.dump(persistPath)
+
+    expect(existsSync(persistPath)).toBe(true)
+    const content = await readFile(persistPath, 'utf-8')
+    expect(content.trim().length).toBeGreaterThan(0)
+    expect(content).toContain('concept-centroid')
+  })
+
+  it('restores from a dumped file on initialize()', async () => {
+    // Load data into first store instance and dump
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+    await store.dump(persistPath)
+
+    // Create a second store instance pointing to the same file
+    const store2 = new OntobiStore()
+    await store2.initialize(persistPath)
+
+    const results = store2.query(`
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?label WHERE {
+        GRAPH <${GRAPH_CENTROID}> { <urn:ontobi:concept:concept-centroid> skos:prefLabel ?label . }
+      }
+    `)
+    expect(results.length).toBe(1)
+    expect(results[0].get('label')).toBe('Centroid')
+  })
+
+  // ---- getNeighbourhood ----------------------------------------------------
+
+  it('getNeighbourhood returns the concept itself as a node', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+
+    const graph = await store.getNeighbourhood('concept-centroid', 1)
+    const ids = graph.nodes.map((n) => n.identifier)
+    expect(ids).toContain('concept-centroid')
+  })
+
+  it('getNeighbourhood returns edges to neighbours when both graphs are loaded', async () => {
+    await store.loadTriples(generateTriples(centroid, GRAPH_CENTROID))
+    await store.loadTriples(generateTriples(kMeans, GRAPH_KMEANS))
+
+    const graph = await store.getNeighbourhood('concept-centroid', 1)
+
+    // centroid has skos:broader → k-means-clustering
+    const edgeSources = graph.edges.map((e) => e.source)
+    const edgeTargets = graph.edges.map((e) => e.target)
+    expect(
+      edgeSources.includes('concept-centroid') || edgeTargets.includes('concept-centroid')
+    ).toBe(true)
+  })
+
+  it('getNeighbourhood returns empty graph for unknown concept', async () => {
+    const graph = await store.getNeighbourhood('concept-does-not-exist', 1)
+    expect(graph.nodes).toHaveLength(0)
+    expect(graph.edges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #1

## Summary
- Adds 15 unit tests for `OntobiStore` covering all public methods: `initialize`, `loadTriples`, `clearGraph`, `ask`, `query`, `queryRaw`, `dump`, restore-on-init, and `getNeighbourhood`
- Fixes a bug in `getNeighbourhood`: all SPARQL triple patterns now use `GRAPH ?g { }` wrappers — Oxigraph stores every concept in its own named graph, so bare `WHERE { ?s ?p ?o }` only queries the empty default graph

## Key discovery documented in code
Oxigraph WASM is in-memory only; persistence is manual (`dump` → N-Quads on disk, `load` on startup). All queries against indexed data must be graph-scoped.