### PR TITLE
refactor: CLI ergonomics and accurate architecture diagram

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,76 +5,50 @@
 ```mermaid
 flowchart TB
 
-    subgraph TOP_ROW[" "]
-        direction LR
-
-        subgraph VAULT["🗂 Obsidian Vault"]
-            MD[".md files  ·  YAML frontmatter<br/>──────────────<br/>skos:prefLabel · skos:definition<br/>skos:broader · skos:narrower · skos:related<br/>schema:identifier · dateCreated · @type"]
-        end
-
-        subgraph ONTOBI_STACK[" "]
-            direction TB
-
-            subgraph ONTOBI_PLUGIN["@ontobi/obsidian  —  Obsidian Plugin (TypeScript · thin UI wrapper)"]
-                direction LR
-                OBS_BRIDGE["Vault Event Bridge<br/>──────────────<br/>vault.on('modify') → core.reindexFile()<br/>vault.on('delete') → core.removeFile()<br/>plugin settings · ribbon + command palette"]
-                OBS_VIZ["Cytoscape.js · Graph View<br/>──────────────<br/>core.getNeighbourhood(id, depth)<br/>→ node/edge JSON → canvas<br/>CoSE force-directed layout"]
-            end
-
-            subgraph ONTOBI_CORE["@ontobi/core  —  Core Library (TypeScript · standalone · no Obsidian deps)"]
-                direction LR
-                CLI["CLI Entry Point<br/>──────────────<br/>ontobi serve · ontobi index<br/>chokidar watcher → reindexFile()<br/>SIGINT → graceful shutdown"]
-                API["OntobiCore class<br/>──────────────<br/>start() · stop()<br/>indexVault() · reindexFile() · removeFile()<br/>query(sparql) · getNeighbourhood()"]
-                PARSER["Frontmatter Parser<br/>──────────────<br/>gray-matter → YAML extraction<br/>custom prefix mapper (no jsonld dep)<br/>wikilink resolver · date normalizer"]
-                OXI["Oxigraph · RDF Triplestore (WASM)<br/>──────────────<br/>in-process · in-memory<br/>SKOS + Schema.org in one graph<br/>SPARQL 1.1 · property paths<br/>per-file named graph → incremental invalidation<br/>N-Quads dump/restore for persistence"]
-                HTTP["SPARQL Endpoint<br/>──────────────<br/>localhost:14321<br/>GET ?query= · POST body<br/>SELECT · ASK · CONSTRUCT"]
-                CLI --> API
-                API --> PARSER
-                API --> OXI
-                PARSER --> OXI
-                OXI --> HTTP
-            end
-
-            ONTOBI_PLUGIN -- "npm dep · in-process" --> ONTOBI_CORE
-        end
+    subgraph VAULT["Obsidian Vault"]
+        MD[".md files  ·  YAML frontmatter<br/>──────────────<br/>skos:prefLabel · skos:definition<br/>skos:broader · skos:narrower · skos:related<br/>schema:identifier · dateCreated · @type"]
     end
 
-    subgraph BOTTOM_ROW[" "]
+    subgraph CORE["ontobi-core  —  Rust binary"]
         direction LR
-
-        subgraph MCP_SERVER["@ontobi/mcp  —  MCP Server (TypeScript · separate process)"]
-            direction LR
-            SPARQL_CLIENT["SPARQL Client<br/>──────────────<br/>fetch → localhost:14321<br/>no local graph · on demand"]
-            FILE_READER["File Reader<br/>──────────────<br/>fs.readFile(vaultPath + relPath)<br/>no Obsidian dependency"]
-            TOOLS["MCP Tool Interface<br/>──────────────<br/>search_concepts → SPARQL<br/>expand_concept_graph → SPARQL<br/>get_concept_content → fs.readFile"]
-            SPARQL_CLIENT --> TOOLS
-            FILE_READER --> TOOLS
-        end
-
-        AGENT["LLM Agent<br/>──────────────<br/>search_concepts<br/>→ expand_concept_graph<br/>→ get_concept_content<br/>metadata-first · scoped context"]
+        WATCHER["watcher / CLI<br/>──────────────<br/>ontobi serve · ontobi index<br/>notify-debouncer-mini 500 ms<br/>SIGINT → dump → exit"]
+        PARSER["parser<br/>──────────────<br/>serde_yaml frontmatter<br/>wikilink resolver<br/>ConceptMetadata"]
+        TRIPLES["triples<br/>──────────────<br/>ConceptMetadata → N-Quads<br/>named graph per file"]
+        STORE["store<br/>──────────────<br/>Oxigraph (in-memory)<br/>union-graph SPARQL<br/>N-Quads persistence"]
+        ENDPOINT["endpoint<br/>──────────────<br/>axum · 127.0.0.1:14321<br/>GET + POST /sparql<br/>SELECT · ASK"]
+        WATCHER --> PARSER --> TRIPLES --> STORE --> ENDPOINT
     end
 
-    MD -- "fs.readFile (CLI)" --> CLI
-    MD -- "vault.read() (plugin)" --> OBS_BRIDGE
+    subgraph MCP["@ontobi/mcp  —  MCP Server (TypeScript · separate process)"]
+        direction LR
+        SPARQL_CLIENT["SPARQL Client<br/>──────────────<br/>fetch → :14321<br/>no local graph · on demand"]
+        FILE_READER["File Reader<br/>──────────────<br/>fs.readFile(vaultPath + relPath)<br/>no Obsidian dependency"]
+        TOOLS["MCP Tools<br/>──────────────<br/>search_concepts → SPARQL<br/>expand_concept_graph → SPARQL<br/>get_concept_content → fs.readFile"]
+        SPARQL_CLIENT --> TOOLS
+        FILE_READER --> TOOLS
+    end
+
+    subgraph PLUGIN["@ontobi/obsidian  —  Obsidian Plugin (TypeScript · post-MVP)"]
+        OBS_VIZ["Cytoscape.js · Graph View<br/>──────────────<br/>SPARQL → node/edge JSON → canvas<br/>CoSE force-directed layout"]
+    end
+
+    AGENT["LLM Agent<br/>──────────────<br/>search_concepts<br/>→ expand_concept_graph<br/>→ get_concept_content<br/>metadata-first · scoped context"]
+
+    MD -- "walkdir (index)<br/>notify (watch)" --> WATCHER
     MD -- "fs.readFile · on demand" --> FILE_READER
-    OBS_BRIDGE -- "reindexFile(path)" --> API
-    API -- "getNeighbourhood() → GraphData" --> OBS_VIZ
-    HTTP -- "SPARQL · on demand" --> SPARQL_CLIENT
-    TOOLS -- "MCP protocol" --> AGENT
+    ENDPOINT -- "SPARQL HTTP · on demand" --> SPARQL_CLIENT
+    ENDPOINT -- "SPARQL HTTP" --> OBS_VIZ
+    TOOLS -- "MCP stdio" --> AGENT
 
     style AGENT         fill:#2d6a4f,color:#fff,stroke:#1b4332,stroke-width:2px
-    style OXI           fill:#7b61ff,color:#fff,stroke:#5a3fd6,stroke-width:2px
-    style HTTP          fill:#f4a261,color:#222,stroke:#e76f51,stroke-width:2px,stroke-dasharray:5 3
-    style API           fill:#2d6a4f,color:#fff,stroke:#1b4332,stroke-width:2px
-    style CLI           fill:#344e41,color:#fff,stroke:#1b4332,stroke-width:2px
+    style STORE         fill:#7b61ff,color:#fff,stroke:#5a3fd6,stroke-width:2px
+    style ENDPOINT      fill:#f4a261,color:#222,stroke:#e76f51,stroke-width:2px,stroke-dasharray:5 3
+    style WATCHER       fill:#344e41,color:#fff,stroke:#1b4332,stroke-width:2px
     style OBS_VIZ       fill:#4a90d9,color:#fff,stroke:#2c6fad,stroke-width:2px
     style FILE_READER   fill:#adb5bd,color:#222,stroke:#6c757d,stroke-width:2px
-    style ONTOBI_PLUGIN fill:#eef6ff,stroke:#4a90d9,stroke-width:2px,stroke-dasharray:4 3
-    style ONTOBI_CORE   fill:#f8f4ff,stroke:#7b61ff,stroke-width:2px
-    style MCP_SERVER    fill:#f0fff4,stroke:#2d6a4f,stroke-width:2px
-    style TOP_ROW       fill:none,stroke:none
-    style ONTOBI_STACK  fill:none,stroke:none
-    style BOTTOM_ROW    fill:none,stroke:none
+    style PLUGIN        fill:#eef6ff,stroke:#4a90d9,stroke-width:2px,stroke-dasharray:4 3
+    style CORE          fill:#f8f4ff,stroke:#7b61ff,stroke-width:2px
+    style MCP           fill:#f0fff4,stroke:#2d6a4f,stroke-width:2px
 ```
 
 ---
@@ -85,28 +59,28 @@ flowchart TB
 
 Standalone Rust binary. No Node.js or Obsidian dependency.
 
-| Module | Responsibility |
-|---|---|
-| **parser** (`parser/wikilink.rs`, `parser/frontmatter.rs`) | `serde_yaml` frontmatter extraction; wikilink resolver; date normaliser; produces `ConceptMetadata` |
-| **triples** (`triples/mod.rs`) | Converts `ConceptMetadata` to N-Quads strings; places each concept in its own named graph (`file:///...`) for incremental invalidation |
-| **store** (`store/mod.rs`) | `OntobiStore` wrapping `oxigraph::store::Store` (in-memory, no RocksDB); N-Quads persistence to `.ontobi/store.nq`; union-graph SPARQL |
-| **endpoint** (`endpoint/mod.rs`) | axum HTTP server on `localhost:14321`; `GET /sparql?query=` and `POST /sparql`; returns `application/sparql-results+json` |
-| **watcher** (`watcher/mod.rs`) | `notify-debouncer-mini` recursive vault watcher; debounced 500 ms; calls `store.reindex_file()` / `store.remove_file()` |
-| **CLI** (`main.rs`) | `ontobi serve --vault <path> [--index]` and `ontobi index`; graceful SIGINT shutdown with N-Quads persistence |
+| Module                                                     | Responsibility                                                                                                                         |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **parser** (`parser/wikilink.rs`, `parser/frontmatter.rs`) | `serde_yaml` frontmatter extraction; wikilink resolver; date normaliser; produces `ConceptMetadata`                                    |
+| **triples** (`triples/mod.rs`)                             | Converts `ConceptMetadata` to N-Quads strings; places each concept in its own named graph (`file:///...`) for incremental invalidation |
+| **store** (`store/mod.rs`)                                 | `OntobiStore` wrapping `oxigraph::store::Store` (in-memory, no RocksDB); N-Quads persistence to `.ontobi/store.nq`; union-graph SPARQL |
+| **endpoint** (`endpoint/mod.rs`)                           | axum HTTP server on `localhost:14321`; `GET /sparql?query=` and `POST /sparql`; returns `application/sparql-results+json`              |
+| **watcher** (`watcher/mod.rs`)                             | `notify-debouncer-mini` recursive vault watcher; debounced 500 ms; calls `store.reindex_file()` / `store.remove_file()`                |
+| **CLI** (`main.rs`)                                        | `ontobi serve --vault <path> [--index]` and `ontobi index`; graceful SIGINT shutdown with N-Quads persistence                          |
 
 ### `@ontobi/mcp` — MCP Server
 
 Separate process. Queries `ontobi-core`'s SPARQL endpoint on demand. No local graph, no Obsidian dependency.
 
-| Tool | Input | Action | Returns |
-|---|---|---|---|
-| `search_concepts` | `query: string, limit?: number` | SPARQL `REGEX` over labels + definitions | Concept list with metadata — no document bodies |
+| Tool                   | Input                                | Action                                                                  | Returns                                                  |
+| ---------------------- | ------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------- |
+| `search_concepts`      | `query: string, limit?: number`      | SPARQL `REGEX` over labels + definitions                                | Concept list with metadata — no document bodies          |
 | `expand_concept_graph` | `concept_id: string, depth?: number` | SPARQL property path `(skos:broader\|skos:narrower\|skos:related){1,N}` | Neighbourhood graph (nodes + edges) — no document bodies |
-| `get_concept_content` | `concept_id: string` | Named graph URI → `fs.readFile` | Full `.md` body |
+| `get_concept_content`  | `concept_id: string`                 | Named graph URI → `fs.readFile`                                         | Full `.md` body                                          |
 
 Config via environment: `ONTOBI_SPARQL_ENDPOINT` (default `http://localhost:14321`), `ONTOBI_VAULT_PATH` (required).
 
-### `@ontobi/obsidian` — Obsidian Plugin *(post-MVP)*
+### `@ontobi/obsidian` — Obsidian Plugin _(post-MVP)_
 
 Thin UI wrapper. Communicates with `ontobi-core` via HTTP. No direct import of the Rust binary.
 
@@ -120,27 +94,33 @@ Thin UI wrapper. Communicates with `ontobi-core` via HTTP. No direct import of t
 
 ## Design Decisions
 
-| Decision | Choice | Rejected | Rationale |
-|---|---|---|---|
-| **Graph standard** | RDF — triples + named graphs | LPG (Graphology, NetworkX) | SKOS and Schema.org are native RDF vocabularies; one graph, no schema mapping |
-| **Core implementation** | Rust native binary (`ontobi-core`) | TypeScript + Oxigraph WASM | Eliminates WASM overhead; native Oxigraph crate has full API parity; no `dlltool`/MSVC on Windows required when using `default-features = false` (no RocksDB) |
-| **Triplestore** | Oxigraph 0.4 crate (native Rust, in-memory) | Oxigraph WASM npm, RocksDB | Single crate; SPARQL 1.1 property paths; avoids Electron WASM compilation quirks |
-| **Query language** | SPARQL 1.1 with `set_default_graph_as_union()` | Custom BFS/DFS | All data lives in named graphs (one per file); union-default-graph mode makes plain `SELECT` queries transparent to callers |
-| **Persistence** | Manual N-Quads dump/restore | RocksDB | `default-features = false` disables RocksDB; N-Quads round-trip is sufficient for vault sizes |
-| **Cross-process bridge** | localhost SPARQL HTTP (identical wire format) | `graph.json` file export | `@ontobi/mcp`'s `SparqlClient` requires zero changes; endpoint POST body = raw SPARQL string |
-| **MCP server language** | TypeScript (unchanged) | Rust | `@ontobi/mcp` stays TypeScript; Rust core is a separate process connected via HTTP, not an in-process dependency |
-| **Prefix expansion** | Custom `serde_yaml` deserialization + URI constants | `jsonld` crate | Fixed vocabulary (SKOS + Schema.org); ~50 LOC; avoids a heavy dependency |
-| **Visualisation** | Cytoscape.js in `@ontobi/obsidian` | Cytoscape.js in core | Core must be headless-safe (no DOM) |
-| **File watching** | `notify-debouncer-mini` inside the Rust binary | `chokidar` (Node.js) | Rust-native; no Node.js process required alongside the binary |
-| **Content retrieval** | `fs.readFile(vaultPath + relPath)` in `@ontobi/mcp` | Obsidian `vault.read()` | `.md` files are plain files; concept path encoded in named graph URI |
+| Decision                 | Choice                                              | Rejected                   | Rationale                                                                                                                                                     |
+| ------------------------ | --------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Graph standard**       | RDF — triples + named graphs                        | LPG (Graphology, NetworkX) | SKOS and Schema.org are native RDF vocabularies; one graph, no schema mapping                                                                                 |
+| **Core implementation**  | Rust native binary (`ontobi-core`)                  | TypeScript + Oxigraph WASM | Eliminates WASM overhead; native Oxigraph crate has full API parity; no `dlltool`/MSVC on Windows required when using `default-features = false` (no RocksDB) |
+| **Triplestore**          | Oxigraph 0.4 crate (native Rust, in-memory)         | Oxigraph WASM npm, RocksDB | Single crate; SPARQL 1.1 property paths; avoids Electron WASM compilation quirks                                                                              |
+| **Query language**       | SPARQL 1.1 with `set_default_graph_as_union()`      | Custom BFS/DFS             | All data lives in named graphs (one per file); union-default-graph mode makes plain `SELECT` queries transparent to callers                                   |
+| **Persistence**          | Manual N-Quads dump/restore                         | RocksDB                    | `default-features = false` disables RocksDB; N-Quads round-trip is sufficient for vault sizes                                                                 |
+| **Cross-process bridge** | localhost SPARQL HTTP (identical wire format)       | `graph.json` file export   | `@ontobi/mcp`'s `SparqlClient` requires zero changes; endpoint POST body = raw SPARQL string                                                                  |
+| **MCP server language**  | TypeScript (unchanged)                              | Rust                       | `@ontobi/mcp` stays TypeScript; Rust core is a separate process connected via HTTP, not an in-process dependency                                              |
+| **Prefix expansion**     | Custom `serde_yaml` deserialization + URI constants | `jsonld` crate             | Fixed vocabulary (SKOS + Schema.org); ~50 LOC; avoids a heavy dependency                                                                                      |
+| **Visualisation**        | Cytoscape.js in `@ontobi/obsidian`                  | Cytoscape.js in core       | Core must be headless-safe (no DOM)                                                                                                                           |
+| **File watching**        | `notify-debouncer-mini` inside the Rust binary      | `chokidar` (Node.js)       | Rust-native; no Node.js process required alongside the binary                                                                                                 |
+| **Content retrieval**    | `fs.readFile(vaultPath + relPath)` in `@ontobi/mcp` | Obsidian `vault.read()`    | `.md` files are plain files; concept path encoded in named graph URI                                                                                          |
 
 ---
 
 ## CLI Reference (`ontobi-core`)
 
 ```
-# Start SPARQL endpoint, optionally index vault first
-ontobi serve --vault <path> [--port 14321] [--index]
+# Start SPARQL endpoint and index vault (default behaviour)
+ontobi serve --vault <path> [--port 14321]
+
+# Fast restart: skip indexing, restore from persisted store.nq
+ontobi serve --vault <path> --no-index
+
+# --vault can be omitted if ONTOBI_VAULT_PATH is set in the environment
+ONTOBI_VAULT_PATH=<path> ontobi serve
 
 # One-shot index and exit (for CI / cache rebuild)
 ontobi index --vault <path>

--- a/ontobi-core/src/main.rs
+++ b/ontobi-core/src/main.rs
@@ -4,7 +4,7 @@ mod triples;
 mod endpoint;
 mod watcher;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -18,21 +18,24 @@ struct Cli {
 enum Commands {
     /// Index a vault and start the SPARQL endpoint
     Serve {
-        /// Path to the Obsidian vault root
+        /// Path to the Obsidian vault root.
+        /// Falls back to the ONTOBI_VAULT_PATH environment variable if not set.
         #[arg(long)]
-        vault: String,
+        vault: Option<String>,
         /// SPARQL endpoint port (default: 14321)
         #[arg(long, default_value_t = 14321)]
         port: u16,
-        /// Index vault on startup (default: true)
-        #[arg(long, default_value_t = true)]
-        index: bool,
+        /// Skip vault indexing on startup and load from persisted store.nq instead.
+        /// Useful for fast restarts when the vault has not changed.
+        #[arg(long, default_value_t = false)]
+        no_index: bool,
     },
-    /// Index a vault and exit (no server)
+    /// Index a vault and exit (no server). Writes store.nq for fast cold starts.
     Index {
-        /// Path to the Obsidian vault root
+        /// Path to the Obsidian vault root.
+        /// Falls back to the ONTOBI_VAULT_PATH environment variable if not set.
         #[arg(long)]
-        vault: String,
+        vault: Option<String>,
     },
 }
 
@@ -49,13 +52,27 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Serve { vault, port, index } => {
-            watcher::serve(vault, port, index).await?;
+        Commands::Serve { vault, port, no_index } => {
+            let vault = resolve_vault(vault)?;
+            watcher::serve(vault, port, !no_index).await?;
         }
         Commands::Index { vault } => {
+            let vault = resolve_vault(vault)?;
             store::index_vault_and_exit(&vault).await?;
         }
     }
 
     Ok(())
+}
+
+/// Resolve the vault path from the CLI argument or the ONTOBI_VAULT_PATH env var.
+///
+/// `--vault` takes precedence. If neither is provided the binary exits with a
+/// clear error rather than a cryptic panic.
+fn resolve_vault(vault: Option<String>) -> Result<String> {
+    vault
+        .or_else(|| std::env::var("ONTOBI_VAULT_PATH").ok())
+        .context(
+            "vault path is required: use --vault <path> or set the ONTOBI_VAULT_PATH environment variable",
+        )
 }


### PR DESCRIPTION
## Summary

- Replace `--index` (default `true`, counterintuitive) with `--no-index` (default `false`). Default behaviour is unchanged — `ontobi serve` always indexes on startup. Fast restarts are now explicit: `ontobi serve --no-index`.
- Make `--vault` optional; falls back to `ONTOBI_VAULT_PATH` environment variable, consistent with `@ontobi/mcp` which already reads the same variable. Missing both emits a clear error message.
- Redraw `ARCHITECTURE.md` mermaid diagram to reflect the actual Rust module layout. Removes all references to the deleted TypeScript `@ontobi/core` internals (OntobiCore class, gray-matter, chokidar, Oxigraph WASM).

## Decisions

**`--no-index` over always-indexing:** The fast-restore path (load from `store.nq` without re-scanning) is genuinely useful when the vault is large and unchanged. Removing the flag entirely would eliminate it. `--no-index` makes the opt-out explicit and conventional.

**Env var in the binary:** `@ontobi/mcp` already reads `ONTOBI_VAULT_PATH`. Requiring `--vault` on every `ontobi serve` invocation while the MCP server reads the same path from env creates two configuration surfaces for one value. Accepting the env var in the binary makes `export ONTOBI_VAULT_PATH=<path>` sufficient to configure the entire stack.

## Testing

All 53 existing tests pass (41 unit + 8 integration + 4 doc-tests). No new warnings from `cargo clippy`. The changes touch only `main.rs` argument parsing — no store, endpoint, or watcher logic was modified.

Closes #30