### PR TITLE
fix: index aliases frontmatter as skos:altLabel, searchable via search_concepts

### DIFF
--- a/ontobi-core/src/parser/frontmatter.rs
+++ b/ontobi-core/src/parser/frontmatter.rs
@@ -23,11 +23,19 @@ const KNOWN_PREFIXES: &[(&str, &str)] = &[
 
 // ── YAML keys excluded from the triple bag ────────────────────────────────────
 
-/// Keys consumed as file-level metadata; not emitted as RDF predicates.
+/// Keys consumed as file-level metadata; not emitted as RDF predicates by the
+/// generic extraction loop.
 ///
 /// `@type` is handled by the detection phase and controls `item_type`.
-/// The others are Obsidian-specific organisational fields.
+/// `aliases` is handled by a dedicated pre-loop block that emits one
+/// `skos:altLabel` literal per entry (see [`parse_file`]); it must remain
+/// skipped here to avoid double-emission.
+/// `tags` is an Obsidian-specific organisational field with no RDF semantics.
 const SKIP_KEYS: &[&str] = &["@type", "aliases", "tags"];
+
+/// Full IRI of `skos:altLabel`, used for the Obsidian `aliases:` frontmatter
+/// key. Emitted as plain literals (never IRIs) regardless of value shape.
+const SKOS_ALT_LABEL: &str = "http://www.w3.org/2004/02/skos/core#altLabel";
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -90,6 +98,22 @@ pub fn parse_file(content: &str, rel_path: &str, config: &ParserConfig) -> Optio
     // ── Generic triple extraction ─────────────────────────────────────────────
 
     let mut triples: Vec<(String, RdfObject)> = Vec::new();
+
+    // ── Aliases → skos:altLabel ───────────────────────────────────────────────
+    //
+    // Emit one `skos:altLabel` literal triple per entry in the `aliases:`
+    // frontmatter list. This makes acronyms (GDPR, DAST, RBAC, CVSS, …)
+    // searchable via SPARQL FILTER alongside `skos:prefLabel`.
+    //
+    // Reason for a dedicated block rather than generic bare-key promotion:
+    // alias values must always become literals, even if a vault author
+    // accidentally writes `aliases: ["[[Foo]]"]`. The generic `extract_scalar`
+    // path would emit that as an IRI. This loop bypasses wikilink detection.
+    if let Some(aliases_val) = mapping.get("aliases") {
+        collect_alias_literals(aliases_val, &mut |lit| {
+            triples.push((SKOS_ALT_LABEL.to_string(), RdfObject::Literal(lit)));
+        });
+    }
 
     for (key, value) in &mapping {
         let key_str = match key {
@@ -242,6 +266,37 @@ fn yaml_value_to_str(val: &serde_yaml::Value) -> &str {
     match val {
         serde_yaml::Value::String(s) => s.as_str(),
         _ => "",
+    }
+}
+
+/// Walk an `aliases:` YAML value (scalar, sequence, or null) and call `emit`
+/// for each non-empty string literal found.
+///
+/// Values are always treated as plain literals — wikilink syntax (`[[…]]`)
+/// is NOT unwrapped. Non-string entries (numbers, mappings, null) are ignored.
+/// Empty strings after trim are skipped.
+///
+/// This mirrors the semantics needed for SKOS `altLabel`: alternative lexical
+/// labels are always literals, never IRIs.
+fn collect_alias_literals(value: &serde_yaml::Value, emit: &mut impl FnMut(String)) {
+    match value {
+        serde_yaml::Value::Sequence(seq) => {
+            for item in seq {
+                if let serde_yaml::Value::String(s) = item {
+                    let trimmed = s.trim();
+                    if !trimmed.is_empty() {
+                        emit(trimmed.to_string());
+                    }
+                }
+            }
+        }
+        serde_yaml::Value::String(s) => {
+            let trimmed = s.trim();
+            if !trimmed.is_empty() {
+                emit(trimmed.to_string());
+            }
+        }
+        _ => {}
     }
 }
 
@@ -508,6 +563,91 @@ DOI: "10.1000/xyz"
             related.unwrap().1,
             RdfObject::Iri("urn:ontobi:item:concept-k-nearest-neighbors".to_string()),
             "wikilink must resolve to IRI, not literal"
+        );
+    }
+
+    // ── aliases → skos:altLabel ───────────────────────────────────────────────
+
+    fn alt_labels(item: &ParsedItem) -> Vec<String> {
+        item.triples
+            .iter()
+            .filter(|(p, _)| p == "http://www.w3.org/2004/02/skos/core#altLabel")
+            .filter_map(|(_, obj)| match obj {
+                RdfObject::Literal(s) => Some(s.clone()),
+                RdfObject::Iri(_) => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn aliases_flow_style_emit_alt_label_triples() {
+        let content = "---\nskos:prefLabel: General Data Protection Regulation\naliases: [\"GDPR\", \"DSGVO\"]\n---\n";
+        let item = parse_file(content, "_concepts/GDPR.md", &default_config()).unwrap();
+        let alts = alt_labels(&item);
+        assert_eq!(alts.len(), 2, "expected 2 altLabel triples, got {alts:?}");
+        assert!(alts.contains(&"GDPR".to_string()));
+        assert!(alts.contains(&"DSGVO".to_string()));
+    }
+
+    #[test]
+    fn aliases_block_style_emit_alt_label_triples() {
+        let content =
+            "---\nskos:prefLabel: Role-Based Access Control\naliases:\n  - \"RBAC\"\n  - \"Role-Based\"\n---\n";
+        let item = parse_file(content, "_concepts/RBAC.md", &default_config()).unwrap();
+        let alts = alt_labels(&item);
+        assert_eq!(alts.len(), 2, "expected 2 altLabel triples, got {alts:?}");
+        assert!(alts.contains(&"RBAC".to_string()));
+        assert!(alts.contains(&"Role-Based".to_string()));
+    }
+
+    #[test]
+    fn aliases_empty_list_no_triples() {
+        let content = "---\nskos:prefLabel: Foo\naliases: []\n---\n";
+        let item = parse_file(content, "_concepts/Foo.md", &default_config()).unwrap();
+        assert!(
+            alt_labels(&item).is_empty(),
+            "aliases: [] must emit zero altLabel triples"
+        );
+    }
+
+    #[test]
+    fn aliases_absent_no_triples() {
+        let content = "---\nskos:prefLabel: Foo\nskos:definition: Bar.\n---\n";
+        let item = parse_file(content, "_concepts/Foo.md", &default_config()).unwrap();
+        assert!(
+            alt_labels(&item).is_empty(),
+            "no aliases key means zero altLabel triples"
+        );
+    }
+
+    #[test]
+    fn aliases_wikilink_string_stays_literal() {
+        // Defensive: even if a vault author writes a wikilink-looking alias,
+        // it must be emitted as a literal (never an IRI). Aliases are always
+        // lexical strings in SKOS semantics.
+        let content = "---\nskos:prefLabel: Foo\naliases: [\"[[Bar]]\"]\n---\n";
+        let item = parse_file(content, "_concepts/Foo.md", &default_config()).unwrap();
+        let alts = alt_labels(&item);
+        assert_eq!(alts.len(), 1, "expected 1 altLabel literal, got {alts:?}");
+        assert_eq!(
+            alts[0], "[[Bar]]",
+            "wikilink-looking alias must remain a literal, not become an IRI"
+        );
+        // Also assert no IRI was emitted for this predicate
+        let alt_iri = item
+            .triples
+            .iter()
+            .find(|(p, o)| p.ends_with("#altLabel") && matches!(o, RdfObject::Iri(_)));
+        assert!(alt_iri.is_none(), "altLabel must never be an IRI");
+    }
+
+    #[test]
+    fn aliases_null_no_triples() {
+        let content = "---\nskos:prefLabel: Foo\naliases:\n---\n";
+        let item = parse_file(content, "_concepts/Foo.md", &default_config()).unwrap();
+        assert!(
+            alt_labels(&item).is_empty(),
+            "null aliases must emit zero altLabel triples"
         );
     }
 }

--- a/ontobi-core/tests/integration.rs
+++ b/ontobi-core/tests/integration.rs
@@ -291,3 +291,70 @@ async fn concept_with_space_in_filename_is_indexed() {
         "concept with space in filename must be indexed; got {labels:?}"
     );
 }
+
+/// Regression: `aliases:` frontmatter must surface as `skos:altLabel` literals
+/// so that LLM agents can find concepts by acronym (GDPR, DAST, RBAC, CVSS, …).
+/// Covers the bug tracked by issue #40.
+#[tokio::test]
+async fn aliases_frontmatter_becomes_alt_label_triples() {
+    let vault = TempDir::new().unwrap();
+    let dir = vault.path().join("_concepts");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("GDPR.md"),
+        "---\nskos:prefLabel: General Data Protection Regulation\n\
+         skos:definition: EU data-protection regulation.\n\
+         \"@type\": DefinedTerm\nidentifier: concept-gdpr\n\
+         dateCreated: \"[[01.03.2026]]\"\n\
+         aliases:\n  - \"GDPR\"\n  - \"DSGVO\"\n\
+         tags: []\n---\n",
+    )
+    .unwrap();
+
+    let store = OntobiStore::new().unwrap();
+    store.index_vault(vault.path()).unwrap();
+
+    let app = app(store);
+    let sparql = "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        SELECT ?alt WHERE { ?s skos:altLabel ?alt . } ORDER BY ?alt";
+    let (status, json) = post_sparql(&app, sparql).await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let alts: Vec<&str> = json["results"]["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|b| b["alt"]["value"].as_str())
+        .collect();
+    assert_eq!(
+        alts,
+        vec!["DSGVO", "GDPR"],
+        "aliases must be indexed as skos:altLabel literals"
+    );
+
+    // Also assert the REGEX filter round-trips: searching for an alias returns
+    // the concept via its altLabel.
+    let search_sparql = "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX schema: <https://schema.org/>
+        SELECT ?identifier ?label WHERE {
+          ?concept schema:identifier ?identifier .
+          ?concept skos:prefLabel ?label .
+          OPTIONAL { ?concept skos:altLabel ?altLabel . }
+          FILTER(
+            REGEX(STR(?label), \"GDPR\", \"i\") ||
+            REGEX(STR(?altLabel), \"GDPR\", \"i\")
+          )
+        }";
+    let (status, json) = post_sparql(&app, search_sparql).await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let ids: Vec<&str> = json["results"]["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|b| b["identifier"]["value"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&"concept-gdpr"),
+        "REGEX over skos:altLabel must find concept-gdpr; got {ids:?}"
+    );
+}

--- a/packages/mcp/src/tools/search-concepts.ts
+++ b/packages/mcp/src/tools/search-concepts.ts
@@ -5,7 +5,7 @@ export const searchConceptsInput = z.object({
   query: z
     .string()
     .min(1)
-    .describe('Search term — matched against concept labels and definitions'),
+    .describe('Search term — matched against concept labels, aliases, and definitions'),
   limit: z
     .number()
     .int()
@@ -21,6 +21,8 @@ export interface ConceptSummary {
   identifier: string
   label: string
   definition: string
+  /** All `skos:altLabel` values (from `aliases:` frontmatter). */
+  aliases: string[]
   broader: string[]
   related: string[]
 }
@@ -28,8 +30,9 @@ export interface ConceptSummary {
 /**
  * search_concepts tool handler.
  *
- * Searches concept labels and definitions using SPARQL REGEX.
- * Returns a ranked list of matching concepts with metadata (no document bodies).
+ * Searches concept labels, aliases (`skos:altLabel`), and definitions using
+ * SPARQL REGEX. Returns a ranked list of matching concepts with metadata
+ * (no document bodies).
  *
  * Design: metadata-first. The agent inspects summaries and navigates the
  * graph before any full .md body enters the context window.
@@ -41,6 +44,9 @@ export async function searchConcepts(
   // Escape regex special chars in query string
   const escaped = input.query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+  // Reason: altLabel is OPTIONAL because not every concept has aliases.
+  // It is not projected in SELECT, so DISTINCT over (identifier, label,
+  // definition) collapses the multi-row join from multiple altLabels.
   const sparqlQuery = `
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX schema: <https://schema.org/>
@@ -49,9 +55,11 @@ export async function searchConcepts(
       ?concept schema:identifier ?identifier .
       ?concept skos:prefLabel ?label .
       OPTIONAL { ?concept skos:definition ?definition . }
+      OPTIONAL { ?concept skos:altLabel ?altLabel . }
       FILTER(
         REGEX(STR(?label), "${escaped}", "i") ||
-        REGEX(STR(?definition), "${escaped}", "i")
+        REGEX(STR(?definition), "${escaped}", "i") ||
+        REGEX(STR(?altLabel), "${escaped}", "i")
       )
     }
     LIMIT ${input.limit}
@@ -59,21 +67,42 @@ export async function searchConcepts(
 
   const rows = await sparql.select(sparqlQuery)
 
-  // For each result, fetch broader + related (two extra queries batched by identifier)
+  // Defensive JS-side dedup by identifier. SPARQL DISTINCT already collapses
+  // on (identifier, label, definition), but per-graph triple duplication
+  // (see relation-query comment below) can still produce duplicate rows.
+  const seenIds = new Set<string>()
+  const uniqueRows = rows.filter((r) => {
+    const id = r['identifier']
+    if (!id || seenIds.has(id)) return false
+    seenIds.add(id)
+    return true
+  })
+
+  // For each result, fetch broader + related + aliases in one query.
   const results: ConceptSummary[] = await Promise.all(
-    rows.map(async (row) => {
+    uniqueRows.map(async (row) => {
       const identifier = row['identifier'] ?? ''
       const subjectUri = `urn:ontobi:item:${identifier}`
 
+      // Reason: union broader/related/altLabel into a single round-trip to
+      // keep per-hit latency at one query. `?rel` distinguishes the three
+      // categories in the result rows.
       const relQuery = `
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX schema: <https://schema.org/>
 
-        SELECT DISTINCT ?rel ?targetId WHERE {
-          VALUES ?pred { skos:broader skos:related }
-          <${subjectUri}> ?pred ?target .
-          ?target schema:identifier ?targetId .
-          BIND(REPLACE(STR(?pred), ".*#", "") AS ?rel)
+        SELECT DISTINCT ?rel ?value WHERE {
+          {
+            VALUES ?pred { skos:broader skos:related }
+            <${subjectUri}> ?pred ?target .
+            ?target schema:identifier ?value .
+            BIND(REPLACE(STR(?pred), ".*#", "") AS ?rel)
+          }
+          UNION
+          {
+            <${subjectUri}> skos:altLabel ?value .
+            BIND("alias" AS ?rel)
+          }
         }
       `
 
@@ -86,19 +115,25 @@ export async function searchConcepts(
       const relRows = await sparql.select(relQuery)
       const broader = [
         ...new Set(
-          relRows.filter((r) => r['rel'] === 'broader').map((r) => r['targetId'] ?? ''),
+          relRows.filter((r) => r['rel'] === 'broader').map((r) => r['value'] ?? ''),
         ),
-      ].filter((id) => id !== '')
+      ].filter((v) => v !== '')
       const related = [
         ...new Set(
-          relRows.filter((r) => r['rel'] === 'related').map((r) => r['targetId'] ?? ''),
+          relRows.filter((r) => r['rel'] === 'related').map((r) => r['value'] ?? ''),
         ),
-      ].filter((id) => id !== '')
+      ].filter((v) => v !== '')
+      const aliases = [
+        ...new Set(
+          relRows.filter((r) => r['rel'] === 'alias').map((r) => r['value'] ?? ''),
+        ),
+      ].filter((v) => v !== '')
 
       return {
         identifier,
         label: row['label'] ?? identifier,
         definition: row['definition'] ?? '',
+        aliases,
         broader,
         related,
       }

--- a/packages/mcp/test/search-concepts.test.ts
+++ b/packages/mcp/test/search-concepts.test.ts
@@ -8,9 +8,12 @@ import type { SparqlClient, SparqlRow } from '../src/sparql-client.js'
  * observed in production (duplicated rows from union-of-named-graphs).
  */
 class MockSparqlClient {
+  public readonly calls: string[] = []
+
   constructor(private readonly responses: Array<(query: string) => SparqlRow[] | null>) {}
 
   async select(query: string): Promise<SparqlRow[]> {
+    this.calls.push(query)
     for (const matcher of this.responses) {
       const result = matcher(query)
       if (result !== null) return result
@@ -23,24 +26,34 @@ class MockSparqlClient {
   }
 }
 
+// Helper: matches the main search query (by projected column names).
+const isMainSearch = (q: string): boolean =>
+  q.includes('?identifier ?label ?definition') && q.includes('skos:altLabel')
+
+// Helper: matches the per-concept relation query (by VALUES clause + altLabel UNION).
+const isRelationQuery = (q: string): boolean =>
+  q.includes('VALUES ?pred') && q.includes('skos:altLabel')
+
+// ── broader/related deduplication (regression protection from PR #44) ────────
+
 describe('searchConcepts — broader/related deduplication', () => {
   it('deduplicates broader IDs that appear multiple times in SPARQL results', async () => {
     const mock = new MockSparqlClient([
-      // First query: the main search
+      // Main search query
       (q) =>
-        q.includes('?identifier ?label ?definition')
+        isMainSearch(q)
           ? [{ identifier: 'concept-foo', label: 'Foo', definition: 'The Foo concept.' }]
           : null,
-      // Second query: the broader/related lookup, simulating duplicated rows
+      // Relation lookup, simulating duplicated rows across named graphs
       (q) =>
-        q.includes('skos:broader skos:related')
+        isRelationQuery(q)
           ? [
-              { rel: 'broader', targetId: 'concept-bar' },
-              { rel: 'broader', targetId: 'concept-bar' },
-              { rel: 'broader', targetId: 'concept-bar' },
-              { rel: 'related', targetId: 'concept-baz' },
-              { rel: 'related', targetId: 'concept-baz' },
-              { rel: 'related', targetId: 'concept-qux' },
+              { rel: 'broader', value: 'concept-bar' },
+              { rel: 'broader', value: 'concept-bar' },
+              { rel: 'broader', value: 'concept-bar' },
+              { rel: 'related', value: 'concept-baz' },
+              { rel: 'related', value: 'concept-baz' },
+              { rel: 'related', value: 'concept-qux' },
             ]
           : null,
     ])
@@ -51,24 +64,24 @@ describe('searchConcepts — broader/related deduplication', () => {
     )
 
     expect(results).toHaveLength(1)
-    expect(results[0].broader).toEqual(['concept-bar'])
-    expect(results[0].related).toEqual(['concept-baz', 'concept-qux'])
+    expect(results[0]?.broader).toEqual(['concept-bar'])
+    expect(results[0]?.related).toEqual(['concept-baz', 'concept-qux'])
   })
 
   it('preserves the order of first occurrence when deduplicating', async () => {
     const mock = new MockSparqlClient([
       (q) =>
-        q.includes('?identifier ?label ?definition')
+        isMainSearch(q)
           ? [{ identifier: 'concept-x', label: 'X', definition: '' }]
           : null,
       (q) =>
-        q.includes('skos:broader skos:related')
+        isRelationQuery(q)
           ? [
-              { rel: 'related', targetId: 'concept-a' },
-              { rel: 'related', targetId: 'concept-b' },
-              { rel: 'related', targetId: 'concept-a' }, // dup of first
-              { rel: 'related', targetId: 'concept-c' },
-              { rel: 'related', targetId: 'concept-b' }, // dup of second
+              { rel: 'related', value: 'concept-a' },
+              { rel: 'related', value: 'concept-b' },
+              { rel: 'related', value: 'concept-a' }, // dup of first
+              { rel: 'related', value: 'concept-c' },
+              { rel: 'related', value: 'concept-b' }, // dup of second
             ]
           : null,
     ])
@@ -78,21 +91,21 @@ describe('searchConcepts — broader/related deduplication', () => {
       mock as unknown as SparqlClient,
     )
 
-    expect(results[0].related).toEqual(['concept-a', 'concept-b', 'concept-c'])
+    expect(results[0]?.related).toEqual(['concept-a', 'concept-b', 'concept-c'])
   })
 
   it('filters out empty-string target IDs', async () => {
     const mock = new MockSparqlClient([
       (q) =>
-        q.includes('?identifier ?label ?definition')
+        isMainSearch(q)
           ? [{ identifier: 'concept-x', label: 'X', definition: '' }]
           : null,
       (q) =>
-        q.includes('skos:broader skos:related')
+        isRelationQuery(q)
           ? [
-              { rel: 'broader', targetId: 'concept-a' },
-              { rel: 'broader', targetId: '' },
-              { rel: 'related', targetId: 'concept-b' },
+              { rel: 'broader', value: 'concept-a' },
+              { rel: 'broader', value: '' },
+              { rel: 'related', value: 'concept-b' },
             ]
           : null,
     ])
@@ -102,17 +115,17 @@ describe('searchConcepts — broader/related deduplication', () => {
       mock as unknown as SparqlClient,
     )
 
-    expect(results[0].broader).toEqual(['concept-a'])
-    expect(results[0].related).toEqual(['concept-b'])
+    expect(results[0]?.broader).toEqual(['concept-a'])
+    expect(results[0]?.related).toEqual(['concept-b'])
   })
 
   it('returns empty arrays when no relations exist', async () => {
     const mock = new MockSparqlClient([
       (q) =>
-        q.includes('?identifier ?label ?definition')
+        isMainSearch(q)
           ? [{ identifier: 'concept-solo', label: 'Solo', definition: '' }]
           : null,
-      (q) => (q.includes('skos:broader skos:related') ? [] : null),
+      (q) => (isRelationQuery(q) ? [] : null),
     ])
 
     const results = await searchConcepts(
@@ -120,28 +133,167 @@ describe('searchConcepts — broader/related deduplication', () => {
       mock as unknown as SparqlClient,
     )
 
-    expect(results[0].broader).toEqual([])
-    expect(results[0].related).toEqual([])
+    expect(results[0]?.broader).toEqual([])
+    expect(results[0]?.related).toEqual([])
+    expect(results[0]?.aliases).toEqual([])
   })
 
   it('includes DISTINCT in the SPARQL query to deduplicate at the store level', async () => {
-    let capturedRelQuery = ''
     const mock = new MockSparqlClient([
       (q) =>
-        q.includes('?identifier ?label ?definition')
+        isMainSearch(q)
           ? [{ identifier: 'concept-x', label: 'X', definition: '' }]
           : null,
-      (q) => {
-        if (q.includes('skos:broader skos:related')) {
-          capturedRelQuery = q
-          return []
-        }
-        return null
-      },
+      (q) => (isRelationQuery(q) ? [] : null),
     ])
 
     await searchConcepts({ query: 'X', limit: 10 }, mock as unknown as SparqlClient)
 
-    expect(capturedRelQuery).toMatch(/SELECT\s+DISTINCT/)
+    const relationCall = mock.calls.find(isRelationQuery) ?? ''
+    expect(relationCall).toMatch(/SELECT\s+DISTINCT/)
+  })
+})
+
+// ── aliases surfacing (new in this PR) ────────────────────────────────────────
+
+describe('searchConcepts — aliases surfacing', () => {
+  it('populates aliases array from skos:altLabel triples', async () => {
+    const mock = new MockSparqlClient([
+      (q) =>
+        isMainSearch(q)
+          ? [{ identifier: 'concept-gdpr', label: 'General Data Protection Regulation', definition: 'EU regulation.' }]
+          : null,
+      (q) =>
+        isRelationQuery(q)
+          ? [
+              { rel: 'alias', value: 'GDPR' },
+              { rel: 'alias', value: 'DSGVO' },
+              { rel: 'broader', value: 'concept-privacy' },
+            ]
+          : null,
+    ])
+
+    const results = await searchConcepts(
+      { query: 'GDPR', limit: 10 },
+      mock as unknown as SparqlClient,
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.aliases).toEqual(['GDPR', 'DSGVO'])
+    expect(results[0]?.broader).toEqual(['concept-privacy'])
+    expect(results[0]?.related).toEqual([])
+  })
+
+  it('returns empty aliases array when concept has no altLabels', async () => {
+    const mock = new MockSparqlClient([
+      (q) =>
+        isMainSearch(q)
+          ? [{ identifier: 'concept-foo', label: 'Foo', definition: 'The Foo concept.' }]
+          : null,
+      (q) => (isRelationQuery(q) ? [] : null),
+    ])
+
+    const results = await searchConcepts(
+      { query: 'Foo', limit: 10 },
+      mock as unknown as SparqlClient,
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.aliases).toEqual([])
+  })
+
+  it('matches against aliases in SPARQL FILTER (query shape contains altLabel REGEX)', async () => {
+    const mock = new MockSparqlClient([
+      (q) => (isMainSearch(q) ? [] : null),
+    ])
+
+    await searchConcepts({ query: 'CVSS', limit: 10 }, mock as unknown as SparqlClient)
+
+    // The main search query must REGEX-match against altLabel too
+    const mainQuery = mock.calls[0] ?? ''
+    expect(mainQuery).toContain('skos:altLabel')
+    expect(mainQuery).toMatch(/REGEX\(STR\(\?altLabel\)/)
+  })
+})
+
+// ── identifier-row deduplication (belt-and-braces with SPARQL DISTINCT) ──────
+
+describe('searchConcepts — row deduplication', () => {
+  it('deduplicates identifier rows before issuing per-concept queries', async () => {
+    // Oxigraph's default-graph-as-union behaviour can produce duplicate rows
+    // even with DISTINCT when the same concept appears across multiple graphs.
+    const mock = new MockSparqlClient([
+      (q) =>
+        isMainSearch(q)
+          ? [
+              { identifier: 'concept-foo', label: 'Foo', definition: 'Foo.' },
+              { identifier: 'concept-foo', label: 'Foo', definition: 'Foo.' },
+              { identifier: 'concept-foo', label: 'Foo', definition: 'Foo.' },
+            ]
+          : null,
+      (q) => (isRelationQuery(q) ? [] : null),
+    ])
+
+    const results = await searchConcepts(
+      { query: 'Foo', limit: 10 },
+      mock as unknown as SparqlClient,
+    )
+
+    // Exactly one result and exactly one relation query (per unique identifier)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.identifier).toBe('concept-foo')
+    const relationCalls = mock.calls.filter(isRelationQuery)
+    expect(relationCalls).toHaveLength(1)
+  })
+
+  it('deduplicates broader/related/aliases values from duplicate relation rows', async () => {
+    const mock = new MockSparqlClient([
+      (q) =>
+        isMainSearch(q)
+          ? [{ identifier: 'concept-rbac', label: 'Role-Based Access Control', definition: 'RBAC.' }]
+          : null,
+      (q) =>
+        isRelationQuery(q)
+          ? [
+              { rel: 'broader', value: 'concept-authorization' },
+              { rel: 'broader', value: 'concept-authorization' },
+              { rel: 'related', value: 'concept-least-privilege' },
+              { rel: 'related', value: 'concept-least-privilege' },
+              { rel: 'alias', value: 'RBAC' },
+              { rel: 'alias', value: 'RBAC' },
+            ]
+          : null,
+    ])
+
+    const results = await searchConcepts(
+      { query: 'RBAC', limit: 10 },
+      mock as unknown as SparqlClient,
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.broader).toEqual(['concept-authorization'])
+    expect(results[0]?.related).toEqual(['concept-least-privilege'])
+    expect(results[0]?.aliases).toEqual(['RBAC'])
+  })
+
+  it('filters out empty identifier rows defensively', async () => {
+    const mock = new MockSparqlClient([
+      (q) =>
+        isMainSearch(q)
+          ? [
+              { identifier: '', label: 'BadRow', definition: '' },
+              { identifier: 'concept-good', label: 'Good', definition: '' },
+            ]
+          : null,
+      (q) => (isRelationQuery(q) ? [] : null),
+    ])
+
+    const results = await searchConcepts(
+      { query: 'Any', limit: 10 },
+      mock as unknown as SparqlClient,
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.identifier).toBe('concept-good')
   })
 })


### PR DESCRIPTION
## Summary

Fixes the bug reported in #40: the `aliases:` YAML frontmatter list (containing acronyms like `GDPR`, `DAST`, `RBAC`, `CVSS`, `ATT&CK`) was silently skipped during parsing, so LLM agents querying by these acronyms received empty results from `search_concepts`.

This PR indexes aliases as `skos:altLabel` literals and teaches `search_concepts` to match and surface them.

Closes #40

## Changes

### Rust side (`ontobi-core`)

- `frontmatter.rs`: new dedicated pre-loop block in `parse_file` that emits one `skos:altLabel` literal triple per entry in the `aliases:` list. The block bypasses wikilink detection so alias values always become literals (never IRIs), matching SKOS semantics — alternative lexical labels are always plain strings.
- `aliases` remains in `SKIP_KEYS` so the generic loop does not double-emit. Documentation in the const comment explains the contract.
- New helper `collect_alias_literals` handles flow-style (`aliases: ["GDPR", "DSGVO"]`), block-style (`aliases:\n  - "GDPR"\n  - "DSGVO"`), scalar, and null YAML shapes uniformly.

### MCP side (`@ontobi/mcp`)

- `search-concepts.ts`: extended SPARQL `FILTER` to REGEX-match against `skos:altLabel` via an `OPTIONAL` join. Because `altLabel` is not in `SELECT`, `DISTINCT` continues to collapse rows on `(identifier, label, definition)`.
- Per-concept relation query extended with a `UNION` branch fetching altLabels — aliases come free with no extra round-trip.
- New `aliases: string[]` field on `ConceptSummary` surfacing all altLabels for each hit.
- JS-side dedup-by-identifier added as a defensive safety net against duplicate rows (union-of-named-graphs behaviour).
- All response arrays (`broader`, `related`, `aliases`) pass through `new Set` for uniqueness.

## Tests

**Rust (`ontobi-core`):** 65 unit + 9 integration tests pass (6 new unit tests for aliases, 1 new integration test for end-to-end SPARQL round-trip).

**TypeScript (`@ontobi/mcp`):** 6 new vitest cases (all passing) cover:
1. Aliases surfaced from altLabel rows
2. Empty aliases when concept has no altLabels
3. SPARQL FILTER shape includes `REGEX(STR(?altLabel) …)`
4. Identifier-row dedup before per-concept queries fire
5. Relation-value dedup (broader/related/aliases)
6. Empty-identifier rows filtered defensively

## End-to-end verification (212-concept vault)

After indexing, the store contains **219 `skos:altLabel` literals**. Live SPARQL queries via the endpoint:

| Query | Result |
|-------|--------|
| `RBAC` | → `concept-role-based-access-control` · aliases: `[RBAC]` |
| `GDPR` | → `concept-general-data-protection-regulation` · aliases: `[Regulation (EU) 2016/679, GDPR]` |
| `DAST` | → `concept-dynamic-application-security-testing` · aliases: `[DAST]` |
| `SAST` | → `concept-static-application-security-testing` · aliases: `[Static Code Analysis, SAST]` |
| `CVSS` | → `concept-common-vulnerability-scoring-system` · aliases: `[CVSS]` |
| `ATT&CK` | → `concept-mitre-attck-framework` · aliases: `[MITRE ATT&CK, ATT&CK]` |
| `Zero Trust` | → `concept-zero-trust-architecture` · aliases: `[Zero Trust, ZTA]` |

All acronym searches that previously returned `[]` now resolve correctly. Dedup verified: 4 unique identifiers returned for `"Authentication"`, no duplicates.

## Acceptance criteria (from #40)

- [x] After reindexing, the store contains `skos:altLabel` triples for every entry in `aliases:` frontmatter
- [x] `search_concepts({query: "GDPR"})` returns `concept-general-data-protection-regulation`
- [x] `search_concepts({query: "DAST"})` returns `concept-dynamic-application-security-testing`
- [x] Parser unit test covering the alias-to-altLabel mapping
- [x] Integration test that round-trips alias search

## Relationship to PR #44

This PR is independent of #44 (dedup-only fix). Both PRs touch `search-concepts.ts`. If #44 merges first, this PR will have a trivial merge conflict (same dedup lines will already exist). If this PR merges first, #44 becomes a no-op. The dedup logic here is already consistent with #44.